### PR TITLE
Add Vumi Go to channel mappings.

### DIFF
--- a/junebug-entrypoint.sh
+++ b/junebug-entrypoint.sh
@@ -25,4 +25,5 @@ exec jb \
     --amqp-user $AMQP_USER \
     --amqp-password $AMQP_PASSWORD \
     --channels whatsapp:vxyowsup.whatsapp.WhatsAppTransport \
+    --channels vumigo:vumi.transports.vumi_bridge.GoConversationTransport \
     --logging-path .


### PR DESCRIPTION
We need a channel mapping that looks like:

```
vumigo:vumi.transports.vumi_bridge.GoConversationTransport
```

added to the command that launches Junebug.
