### PR TITLE
Add explicit yowsup2 version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM praekeltfoundation/supervisor
 MAINTAINER Praekelt Foundation <dev@praekeltfoundation.org>
 
 RUN apt-get-install.sh libjpeg62 nginx
-RUN pip install -q vxyowsup
-RUN pip install -q vumi==0.6.3
-RUN pip install -q junebug==0.1.1
+RUN pip install -q \
+    yowsup2==2.4.102 \
+    vxyowsup==0.1.5 \
+    vumi==0.6.3 \
+    junebug==0.1.1
 COPY ./docker/nginx.conf /etc/supervisor/conf.d/nginx.conf
 COPY ./docker/junebug.conf /etc/supervisor/conf.d/junebug.conf
 COPY ./junebug-entrypoint.sh /scripts/


### PR DESCRIPTION
The WhatsApp library yowsup2 (https://github.com/tgalal/yowsup) is updated quite frequently and we need to be able to rebuild this image when new versions are released.

Specifically, we need version 2.4.102 to address https://github.com/tgalal/yowsup/issues/1425.
