### PR TITLE
Clean up docker-compose file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ script:
   - docker-compose build
   - docker-compose up -d && sleep 5
   # The simplest possible test - Junebug returns 200/OK when we ask for channels
-  - curl -f http://localhost:8080/jb/channels/
+  - curl -f --user guest:password http://localhost:8080/jb/channels/
   - docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,20 @@
 version: '2'
 services:
   junebug:
-      build: .
-      ports:
-       - "8080:80"
-      links:
-       - redis
-       - rabbitmq
-      environment:
-       REDIS_HOST: 'redis'
-       REDIS_PORT: '6379'
-       AMQP_HOST: 'rabbitmq'
-       AMQP_PORT: '5672'
+    build: .
+    ports:
+      - 8080:80
+    links:
+      - redis
+      - rabbitmq
+    environment:
+      AUTH_USERNAME: guest
+      AUTH_PASSWORD: password
+      REDIS_HOST: redis
+      AMQP_HOST: rabbitmq
   redis:
-      image: redis
+    image: redis
   rabbitmq:
-      image: rabbitmq
-      environment:
-        RABBITMQ_DEFAULT_VHOST: '/guest'
+    image: rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_VHOST: /guest


### PR DESCRIPTION
Indentation was a mess
- Use HTTP auth by default
