### PR TITLE
Add middleware package for RapidPro to AAT SMS support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ junebug==0.1.14
 vxyowsup==0.1.8
 yowsup2==2.5.2
 vxaat==0.5.5
+vumi_msisdn_normalize_middleware

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ junebug==0.1.14
 vxyowsup==0.1.8
 yowsup2==2.5.2
 vxaat==0.5.5
-vumi_msisdn_normalize_middleware
+vumi_msisdn_normalize_middleware==0.1.1


### PR DESCRIPTION
This middleware allows us to remove the + before a MSISDN.

Link to the package we are installing:
https://github.com/praekeltfoundation/vumi_msisdn_normalize_middleware