### PR TITLE
Add new argument to script and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,21 @@ The following command-line options are **always set** by the entrypoint script:
 ### Environment variables
 Several environment variables can be adjusted to configure Junebug. These variables map to command-line options in the entrypoint script as follows:
 
-| Environment variable | Command-line option | Default value |
-|----------------------|---------------------|---------------|
-| `JUNEBUG_INTERFACE`  | `--interface`       |               |
-| `JUNEBUG_PORT`       | `--port`            | `8080`        |
-| `REDIS_HOST`         | `--redis-host`      |               |
-| `REDIS_PORT`         | `--redis-port`      | `6379`        |
-| `REDIS_DB`           | `--redis-db`        | `1`           |
-| `AMQP_HOST`          | `--amqp-host`       |               |
-| `AMQP_PORT`          | `--amqp-port`       | `5679`        |
-| `AMQP_VHOST`         | `--amqp-vhost`      | `guest`       |
-| `AMQP_USER`          | `--amqp-user`       | `guest`       |
-| `AMQP_PASSWORD`      | `--amqp-password`   | `guest`       |
-| `SENTRY_DSN`         | `--sentry-dsn`      |               |
+| Environment variable            | Command-line option               | Default value |
+|---------------------------------|-----------------------------------|---------------|
+| `JUNEBUG_INTERFACE`             | `--interface`                     |               |
+| `JUNEBUG_PORT`                  | `--port`                          | `8080`        |
+| `REDIS_HOST`                    | `--redis-host`                    |               |
+| `REDIS_PORT`                    | `--redis-port`                    | `6379`        |
+| `REDIS_DB`                      | `--redis-db`                      | `1`           |
+| `AMQP_HOST`                     | `--amqp-host`                     |               |
+| `AMQP_PORT`                     | `--amqp-port`                     | `5679`        |
+| `AMQP_VHOST`                    | `--amqp-vhost`                    | `guest`       |
+| `AMQP_USER`                     | `--amqp-user`                     | `guest`       |
+| `AMQP_PASSWORD`                 | `--amqp-password`                 | `guest`       |
+| `RABBITMQ_MANAGEMENT_INTERFACE` | `--rabbitmq-management-interface` |               |
+| `SENTRY_DSN`                    | `--sentry-dsn`                    |               |
+| `ALLOW_EXPIRED_REPLIES`         | `--allow-expired-replies`         |               |
 
 For the Redis and AMQP configuration, it is necessary to set the `_HOST` variables before the other environment variables will be considered.
 

--- a/docs/set-up-junebug-in-mc.md
+++ b/docs/set-up-junebug-in-mc.md
@@ -20,6 +20,9 @@
   - AMQP_VHOST
   - AMQP_USER
   - AMQP_PASSWORD
+* To get more info on the health endpoint for each RabbitMQ queue, you can set
+  the `RABBITMQ_MANAGEMENT_INTERFACE` environment variable. It will return a
+  500 if there are any queues stuck. This is only available for RabbitMQ.
 * Save your app.
 * Check the logs to make sure it started okay.
 * Click on "view" to see the domain name your app is listening on.

--- a/junebug-entrypoint.sh
+++ b/junebug-entrypoint.sh
@@ -54,6 +54,11 @@ if [ "$1" = 'jb' ]; then
             "'amqp://$AMQP_USER:$AMQP_PASSWORD@$AMQP_HOST:$AMQP_PORT/$AMQP_VHOST'"
     fi
 
+    # RABBITMQ MANAGEMENT INTERFACE
+    if [ -n "$RABBITMQ_MANAGEMENT_INTERFACE" ]; then
+        set -- "$@" --rabbitmq-management-interface "$RABBITMQ_MANAGEMENT_INTERFACE"
+    fi
+
     # Sentry
     if [ -n "$SENTRY_DSN" ]; then
         set -- "$@" --sentry-dsn "$SENTRY_DSN"


### PR DESCRIPTION
This is the new argument for the RabbitMQ management interface.

It's to query the queues on the health check.